### PR TITLE
Fix docs about configuring addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ If an element is not automatically imported, it probably does not follow the pol
 
 ### Config variables
 
-The addon can be configured in `config/environment.js` as such:
+The addon can be configured in `ember-cli-build.js` as such:
 
 ```js
-ENV['ember-cli-polymer-bundler'] = {
+'ember-cli-polymer-bundler': {
   option: 'value'
 }
 ```


### PR DESCRIPTION
README suggest that the addon should be configured in environment instead of ember-cli-build.js
File name and code sample are changed in "Config variables" section.