### PR TITLE
Add lazyImport option to prevent downloading the bundle initially

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,8 +49,7 @@ module.exports = {
 		},
 		plugins: ['node'],
 		rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-			'no-process-env': 0,
-			'node/no-unpublished-require': 0
+			'no-process-env': 0
 		})
 	}]
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,13 +29,14 @@ module.exports = {
 			'config/**/*.js',
 			'tests/dummy/config/**/*.js',
 			'lib/**/*.js',
-			'node-tests/unit/**/*.js'
+			'node-tests/**/**/*.js'
 		],
 		excludedFiles: [
 			'addon/**',
 			'addon-test-support/**',
 			'app/**',
-			'tests/dummy/app/**'
+			'tests/dummy/app/**',
+			'node-tests/addon/ember-cli-build-*.js'
 		],
 		parserOptions: {
 			sourceType: 'script',
@@ -48,7 +49,8 @@ module.exports = {
 		},
 		plugins: ['node'],
 		rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-			'no-process-env': 0
+			'no-process-env': 0,
+			'node/no-unpublished-require': 0
 		})
 	}]
 };

--- a/.npmignore
+++ b/.npmignore
@@ -22,6 +22,7 @@
 /ember-cli-build.js
 /testem.js
 /tests/
+/node-tests/
 /yarn.lock
 .gitkeep
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ Defaults to ``.
   }
 ```
 
+#### lazyImport
+
+Allows to set the `rel` attribute of the bundle import tag to "lazy-import" instead of "import" to prevent downloading the bundle.
+
+Defaults to `false`
+
+```js
+  lazyImport: true
+```
+
 ## About
 
 This addon was sponsored by [Fabriquartz](http://www.fabriquartz.com/), a startup based in The Netherlands.

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = {
 			? `<script>window.Polymer = ${JSON.stringify(globalPolymerSettings)};</script>`
 			: '';
 
-		return `${polymerSettings}<link rel="${rel}" href="${href}">`;
+		return `${polymerSettings}\n<link rel="${rel}" href="${href}">`;
 	},
 
 	postprocessTree(type, tree) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,6 +20,7 @@ module.exports = class Config {
 			browsers: app.project.targets && app.project.targets.browsers,
 			enabled: false
 		};
+		this.lazyImport = false;
 
 		// retrieve and apply addon options
 		const addonOptions = app.options['ember-cli-polymer-bundler'] || {};

--- a/node-tests/addon/ember-cli-build-default.js
+++ b/node-tests/addon/ember-cli-build-default.js
@@ -1,0 +1,15 @@
+/* eslint-env node */
+'use strict';
+
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const path = require('path');
+
+module.exports = function(defaults) {
+	const app = new EmberAddon(defaults, {
+		'ember-cli-polymer-bundler': {
+			htmlImportsFile: path.join('tests', 'dummy', 'app', 'elements.html')
+		}
+	});
+
+	return app.toTree();
+};

--- a/node-tests/addon/ember-cli-build-global-polymer-settings.js
+++ b/node-tests/addon/ember-cli-build-global-polymer-settings.js
@@ -1,0 +1,18 @@
+/* eslint-env node */
+'use strict';
+
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const path = require('path');
+
+module.exports = function(defaults) {
+	const app = new EmberAddon(defaults, {
+		'ember-cli-polymer-bundler': {
+			htmlImportsFile: path.join('tests', 'dummy', 'app', 'elements.html'),
+			globalPolymerSettings: {
+				rootPath: '.'
+			}
+		}
+	});
+
+	return app.toTree();
+};

--- a/node-tests/addon/ember-cli-build-lazy-import.js
+++ b/node-tests/addon/ember-cli-build-lazy-import.js
@@ -1,0 +1,21 @@
+/* eslint-env node */
+'use strict';
+
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const path = require('path');
+
+module.exports = function(defaults) {
+	const app = new EmberAddon(defaults, {
+		'ember-cli-polymer-bundler': {
+			htmlImportsFile: path.join('tests', 'dummy', 'app', 'elements.html'),
+			lazyImport: true,
+			autoprefixer: {
+				browsers: ['chrome >= 30', 'firefox >= 32', 'ios >= 9', 'last 1 edge versions'],
+				enabled: true,
+				cascade: false
+			}
+		}
+	});
+
+	return app.toTree();
+};

--- a/node-tests/addon/ember-cli-build-relative-path.js
+++ b/node-tests/addon/ember-cli-build-relative-path.js
@@ -1,0 +1,22 @@
+/* eslint-env node */
+'use strict';
+
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const path = require('path');
+
+module.exports = function(defaults) {
+	const app = new EmberAddon(defaults, {
+		'ember-cli-polymer-bundler': {
+			htmlImportsFile: path.join('tests', 'dummy', 'app', 'elements.html'),
+			useRelativePath: true,
+			bundlerOutput: '../any.html',
+			autoprefixer: {
+				browsers: ['chrome >= 30', 'firefox >= 32', 'ios >= 9', 'last 1 edge versions'],
+				enabled: true,
+				cascade: false
+			}
+		}
+	});
+
+	return app.toTree();
+};

--- a/node-tests/addon/index-test.js
+++ b/node-tests/addon/index-test.js
@@ -137,5 +137,4 @@ describe('ember-cli-build addon options', function() {
 			assertContains(outputFilePath('index.html'), 'href="/');
 		});
 	});
-
 });

--- a/node-tests/addon/index-test.js
+++ b/node-tests/addon/index-test.js
@@ -1,0 +1,118 @@
+/* eslint-env node */
+/* eslint-disable no-sync */
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const rimraf = require('rimraf').sync;
+const exec = require('child_process').exec;
+
+const TEST_TIMEOUT = 120000;
+const MOCK_EMBER_CLI_CONFIGS = {
+	lazyImport: path.resolve(__dirname, 'ember-cli-build-lazy-import.js'),
+	relativePath: path.resolve(__dirname, 'ember-cli-build-relative-path.js'),
+	default: path.resolve(__dirname, 'ember-cli-build-default.js')
+};
+const emberCLIPath = path.resolve(__dirname, '../../node_modules/ember-cli/bin/ember');
+const fixturePath = path.resolve(__dirname, '../..');
+
+function runEmberCommand(packagePath, command) {
+	return new Promise((resolve, reject) =>
+		exec(`${emberCLIPath} ${command}`, {
+			cwd: packagePath
+		}, (err, result) => {
+			if (err) {
+				reject(err);
+			}
+			resolve(result);
+		})
+	);
+}
+
+function outputFilePath(file) {
+	return path.join(fixturePath, 'dist', file);
+}
+
+function assertContains(filePath, regexp) {
+	const fileContent = fs.readFileSync(filePath, 'utf8');
+
+	assert.ok(fileContent.match(regexp), `${filePath} contains ${regexp}`);
+}
+
+function cleanup(packagePath) {
+	rimraf(path.join(packagePath, 'dist'));
+}
+
+function mockConfig(mockFile) {
+	fs.renameSync(path.resolve(fixturePath, 'ember-cli-build.js'), path.resolve(fixturePath, 'ember-cli-build-BACKUP.js'));
+	fs.renameSync(mockFile, path.resolve(fixturePath, 'ember-cli-build.js'));
+}
+
+function restoreConfig(mockFile) {
+	fs.renameSync(path.resolve(fixturePath, 'ember-cli-build.js'), mockFile);
+	fs.renameSync(path.resolve(fixturePath, 'ember-cli-build-BACKUP.js'), path.resolve(fixturePath, 'ember-cli-build.js'));
+}
+
+describe('ember-cli-build addon options', function() {
+	this.timeout(TEST_TIMEOUT);
+
+	context('Setting "lazyImport" to true', () => {
+		const mockConfigFile = MOCK_EMBER_CLI_CONFIGS.lazyImport;
+
+		before(() => {
+			mockConfig(mockConfigFile);
+			return runEmberCommand(fixturePath, 'build --prod');
+		});
+
+		after(() => {
+			restoreConfig(mockConfigFile);
+			return cleanup(fixturePath);
+		});
+
+		it('sets rel attribute of the bundle import tag to "lazy-import"', () => {
+			assertContains(outputFilePath('index.html'), 'rel="lazy-import"');
+		});
+	});
+
+	context('Setting "useRelativePaths" to true', () => {
+		const mockConfigFile = MOCK_EMBER_CLI_CONFIGS.relativePath;
+
+		before(() => {
+			mockConfig(mockConfigFile);
+			return runEmberCommand(fixturePath, 'build --prod');
+		});
+
+		after(() => {
+			restoreConfig(mockConfigFile);
+			return cleanup(fixturePath);
+		});
+
+		it('sets "bundlerOutput" as the href attribute value of the bundle import tag', () => {
+			assertContains(outputFilePath('index.html'), 'href="../any.html"');
+		});
+	});
+
+	context('Using default options', () => {
+		const mockConfigFile = MOCK_EMBER_CLI_CONFIGS.default;
+
+		before(() => {
+			mockConfig(mockConfigFile);
+			return runEmberCommand(fixturePath, 'build --prod');
+		});
+
+		after(() => {
+			restoreConfig(mockConfigFile);
+			return cleanup(fixturePath);
+		});
+
+		it('sets rel attribute of the bundle import to "import"', () => {
+			assertContains(outputFilePath('index.html'), 'rel="import"');
+		});
+
+		it('sets href attribute of the bundle import to an absolute path', () => {
+			assertContains(outputFilePath('index.html'), 'href="/');
+		});
+	});
+
+});

--- a/node-tests/addon/index-test.js
+++ b/node-tests/addon/index-test.js
@@ -12,7 +12,8 @@ const TEST_TIMEOUT = 120000;
 const MOCK_EMBER_CLI_CONFIGS = {
 	lazyImport: path.resolve(__dirname, 'ember-cli-build-lazy-import.js'),
 	relativePath: path.resolve(__dirname, 'ember-cli-build-relative-path.js'),
-	default: path.resolve(__dirname, 'ember-cli-build-default.js')
+	default: path.resolve(__dirname, 'ember-cli-build-default.js'),
+	globalPolymerSettings: path.resolve(__dirname, 'ember-cli-build-global-polymer-settings.js')
 };
 const emberCLIPath = path.resolve(__dirname, '../../node_modules/ember-cli/bin/ember');
 const fixturePath = path.resolve(__dirname, '../..');
@@ -90,6 +91,28 @@ describe('ember-cli-build addon options', function() {
 
 		it('sets "bundlerOutput" as the href attribute value of the bundle import tag', () => {
 			assertContains(outputFilePath('index.html'), 'href="../any.html"');
+		});
+	});
+
+	context('Using "globalPolymerSettings"', () => {
+		const mockConfigFile = MOCK_EMBER_CLI_CONFIGS.globalPolymerSettings;
+
+		before(() => {
+			mockConfig(mockConfigFile);
+			return runEmberCommand(fixturePath, 'build --prod');
+		});
+
+		after(() => {
+			restoreConfig(mockConfigFile);
+			return cleanup(fixturePath);
+		});
+
+		it('writes a script tag with the Polymer global settings', () => {
+			assertContains(outputFilePath('index.html'), '<script>window.Polymer = {');
+		});
+
+		it('writes the script tag before the import tag', () => {
+			assertContains(outputFilePath('index.html'), '</script>\n<link rel="import"');
 		});
 	});
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:ember": "COVERAGE=true ember test",
     "clean-coverage": "rm -rf coverage",
     "merge-coverage": "cp coverage/ember/coverage-final.json coverage/ember.json && cp coverage/node/coverage-final.json coverage/node.json && nyc merge coverage coverage/coverage-final.json",
-    "check-coverage": "istanbul check-coverage coverage/coverage-final.json --statements 40 --functions 40 --branches 40 --lines 40",
+    "check-coverage": "istanbul check-coverage coverage/coverage-final.json --statements 85 --functions 85 --branches 85 --lines 85",
     "commit": "git-cz",
     "posttest": "npm run merge-coverage && npm run report-coverage && npm run check-coverage",
     "report-coverage": "istanbul report --include=coverage/coverage-final.json text",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "ember server",
     "pretest": "npm run clean-coverage",
     "test": "npm run test:node && npm run test:ember",
-    "test:node": "nyc mocha node-tests/**/*-test.js",
+    "test:node": "nyc mocha --recursive 'node-tests/**/*-test.js'",
     "test:ember": "COVERAGE=true ember test",
     "clean-coverage": "rm -rf coverage",
     "merge-coverage": "cp coverage/ember/coverage-final.json coverage/ember.json && cp coverage/node/coverage-final.json coverage/node.json && nyc merge coverage coverage/coverage-final.json",
@@ -55,6 +55,7 @@
     "mocha": "^5.0.0",
     "nyc": "^13.1.0",
     "qunit-dom": "^0.8.0",
+    "rimraf": "^2.6.3",
     "semantic-release": "^15.13.3"
   },
   "keywords": [


### PR DESCRIPTION
Allows to set the `rel` attribute of the bundle import tag to "lazy-import" (not understood by browsers) instead of "import" to prevent downloading the bundle.