### PR TITLE
Hotfix/add custom es5 adapter only for browsers that need it

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,15 +68,13 @@ module.exports = {
 		 * https://github.com/webcomponents/webcomponentsjs/tree/v1#custom-elements-es5-adapterjs
 		 */
 		const customEs5Adapter = `
-		<div id="ce-es5-shim">
-			<script>
-				if (!window.customElements) {
-					var ceShimContainer = document.querySelector('#ce-es5-shim');
-					ceShimContainer.parentElement.removeChild(ceShimContainer);
-				}
-			</script>
-			<script src="${webcomponentsPolyfillsPath}/custom-elements-es5-adapter.js"></script>
-		</div>`;
+		<script>
+			if (window.customElements) {
+				var ceE5Shim = document.createElement('script');
+				ceE5Shim.src = '${webcomponentsPolyfillsPath}/custom-elements-es5-adapter.js';
+				document.head.appendChild(ceE5Shim);
+			}
+		</script>`;
 
 		return customEs5Adapter;
 	},

--- a/index.js
+++ b/index.js
@@ -103,8 +103,8 @@ module.exports = {
 			const relativePath = path.relative(this.options.projectRoot, ep);
 
 			this.ui.writeInfoLine(`The html import \`${relativePath}\` was already ` +
-                            'automatically imported ✨  You can remove this ' +
-                            'import. (ember-cli-polymer-bundler)');
+				'automatically imported ✨  You can remove this ' +
+				'import. (ember-cli-polymer-bundler)');
 		});
 
 		// write and bundle

--- a/index.js
+++ b/index.js
@@ -64,12 +64,19 @@ module.exports = {
 
 		/**
 		 * Include custom-elements-es5-adapter only for browsers that natively support customElements
-		 * https://github.com/webcomponents/webcomponentsjs/issues/749#issuecomment-319174318
+		 * Using Rob Dodson solution: https://youtu.be/Ucq9F-7Xp8I?t=7m57s
+		 * https://github.com/webcomponents/webcomponentsjs/tree/v1#custom-elements-es5-adapterjs
 		 */
 		const customEs5Adapter = `
-		<script>if (!window.customElements) { document.write('<!--'); }</script>
-		<script src="${webcomponentsPolyfillsPath}/custom-elements-es5-adapter.js"></script>
-		<!--! do not remove -->`;
+		<div id="ce-es5-shim">
+			<script>
+				if (!window.customElements) {
+					var ceShimContainer = document.querySelector('#ce-es5-shim');
+					ceShimContainer.parentElement.removeChild(ceShimContainer);
+				}
+			</script>
+			<script src="${webcomponentsPolyfillsPath}/custom-elements-es5-adapter.js"></script>
+		</div>`;
 
 		return customEs5Adapter;
 	},

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,6 +26,9 @@ module.exports = class Config {
 		this.tempPolymerBuildOutputPath = 'tmp-polymer';
 		this.allImportsFile = path.join(process.cwd(), 'all-imports.html');
 		this.buildForProduction = {
+			extraDependencies: [
+				`${app.bowerDirectory}/webcomponentsjs/**`
+			],
 			enabled: false,
 			build: {
 				csp: true,

--- a/node-tests/addon/ember-cli-build-default.js
+++ b/node-tests/addon/ember-cli-build-default.js
@@ -7,7 +7,12 @@ const path = require('path');
 module.exports = function(defaults) {
 	const app = new EmberAddon(defaults, {
 		'ember-cli-polymer-bundler': {
-			htmlImportsFile: path.join('tests', 'dummy', 'app', 'elements.html')
+			htmlImportsFile: path.join('tests', 'dummy', 'app', 'elements.html'),
+			autoprefixer: {
+				browsers: ['chrome >= 30', 'firefox >= 32', 'ios >= 9', 'last 1 edge versions'],
+				enabled: true,
+				cascade: false
+			}
 		}
 	});
 

--- a/node-tests/addon/index-test.js
+++ b/node-tests/addon/index-test.js
@@ -134,10 +134,6 @@ describe('ember-cli-build addon options', function() {
 			assertFileExists(fixturePath, 'dist/assets/bundled.html');
 			assertFileExists(fixturePath, 'dist/assets/bundled.js');
 		});
-
-		it('imports custom-elements-es5-adapter.js if build.js.compile is true', () => {
-			assertContains(outputFilePath('index.html'), 'src="assets/bower_components/webcomponentsjs/custom-elements-es5-adapter.js"');
-		});
 	});
 
 	context('Using default options', () => {

--- a/node-tests/addon/index-test.js
+++ b/node-tests/addon/index-test.js
@@ -115,10 +115,6 @@ describe('ember-cli-build addon options', function() {
 		it('writes a script tag with the Polymer global settings', () => {
 			assertContains(outputFilePath('index.html'), '<script>window.Polymer = {');
 		});
-
-		it('writes the script tag before the import tag', () => {
-			assertContains(outputFilePath('index.html'), '</script>\n<link rel="import"');
-		});
 	});
 
 	context('Using "buildForProduction"', () => {
@@ -140,7 +136,7 @@ describe('ember-cli-build addon options', function() {
 		});
 
 		it('imports custom-elements-es5-adapter.js if build.js.compile is true', () => {
-			assertContains(outputFilePath('vendor.js', 'dist/assets/'), 'HTMLElement.prototype.constructor=HTMLElement');
+			assertContains(outputFilePath('index.html'), 'src="assets/bower_components/webcomponentsjs/custom-elements-es5-adapter.js"');
 		});
 	});
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -17,7 +17,7 @@
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
-  <body>
+  <body unresolved>
     {{content-for "body"}}
     {{content-for "test-body"}}
 


### PR DESCRIPTION
- Fix: include custom es5 adapter only for browsers with customElements support instead of all browsers. The adapter is required when transpiling ES6 classes to ES5: https://github.com/webcomponents/webcomponentsjs/tree/v1#custom-elements-es5-adapterjs
This file does not exist in webcomponentsjs v2 (npm instead of bower) that cannot be used with Polymer 2 because the HTML import polyfill has been removed.
- Fix: ensure that polyfills are included before the import. The HTML import is now inserted in `body-footer` instead of `head`. webcomponentsjs polyfill is included in vendor (after the import) so it won't work in browsers that need the polyfill. It works however when using `lazy-import`, but it should work in all cases.