### PR TITLE
Ensure polyfills (webcomponentsjs) are loaded before the import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # compiled output
 /dist/
 /tmp/
+/deploy/
 
 # dependencies
 /bower_components/

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 # compiled output
 /dist/
 /tmp/
+/deploy/
 
 # dependencies
 /bower_components/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry="https://registry.npmjs.org/"

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry="https://registry.npmjs.org/"

--- a/.releaserc
+++ b/.releaserc
@@ -9,5 +9,12 @@
         "@semantic-release/npm",
         "@semantic-release/git",
         "@semantic-release/github"
+    ],
+    "plugins": [
+      [
+        "@semantic-release/exec", {
+          "publishCmd": "npx ember deploy production --verbose"
+        }
+      ]
     ]
 }

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
     "paper-checkbox": "PolymerElements/paper-checkbox#^2.0.1",
     "paper-input": "PolymerElements/paper-input#^2.0.2",
     "paper-tabs": "PolymerElements/paper-tabs#^2.0.0",
-    "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#^2.0.0",
     "paper-progress": "PolymerElements/paper-progress#^2.0.1",
     "paper-spinner": "PolymerElements/paper-spinner#^2.0.0",
     "paper-slider": "PolymerElements/paper-slider#^2.0.2",

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -2,8 +2,16 @@
 
 module.exports = function(deployTarget) {
 	const ENV = {
-		build: {}
-		// include other plugin configuration that applies to all deploy targets here
+		build: {},
+		'git-ci': {
+			userName: 'adrigzr',
+			userEmail: 'adrigzr@users.noreply.github.com',
+			deployKey: `${process.env.DEPLOY_KEY}\n`
+		},
+		git: {
+			worktreePath: 'deploy',
+			repo: 'git@github.com:BBVAEngineering/ember-cli-polymer-bundler.git'
+		}
 	};
 
 	if (deployTarget === 'development') {

--- a/index.js
+++ b/index.js
@@ -39,20 +39,17 @@ module.exports = {
 
 	// insert polyfills and bundled elements
 	contentFor(type, config) {
-		if (type !== 'head') {
-			return null;
+		if (type === 'head') {
+			const { globalPolymerSettings } = this.options;
+
+			if (globalPolymerSettings) {
+				return `<script>window.Polymer = ${JSON.stringify(globalPolymerSettings)};</script>`;
+			}
+		} else if (type === 'body-footer') {
+			return this.getBundleImport(config);
 		}
 
-		const headContents = [];
-		const { globalPolymerSettings } = this.options;
-
-		if (globalPolymerSettings) {
-			headContents.push(`<script>window.Polymer = ${JSON.stringify(globalPolymerSettings)};</script>`);
-		}
-
-		headContents.push(this.getBundleImport(config));
-
-		return headContents.join('\n');
+		return null;
 	},
 
 	getBundleImport(config) {

--- a/node-tests/addon/index-test.js
+++ b/node-tests/addon/index-test.js
@@ -115,10 +115,6 @@ describe('ember-cli-build addon options', function() {
 		it('writes a script tag with the Polymer global settings', () => {
 			assertContains(outputFilePath('index.html'), '<script>window.Polymer = {');
 		});
-
-		it('writes the script tag before the import tag', () => {
-			assertContains(outputFilePath('index.html'), '</script>\n<link rel="import"');
-		});
 	});
 
 	context('Using "buildForProduction"', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6258,6 +6258,12 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-1.2.0.tgz",
+      "integrity": "sha1-fNc+FuB/BXyAchR6W8OoZ38KtcY=",
+      "dev": true
+    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -7142,6 +7148,309 @@
         "resolve": "^1.5.0",
         "semver": "^5.3.0"
       }
+    },
+    "ember-cli-deploy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-deploy/-/ember-cli-deploy-1.0.2.tgz",
+      "integrity": "sha1-mrORiMiCtXk3QY21s9pvxlsWuRY=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "core-object": "^2.0.0",
+        "dag-map": "^2.0.1",
+        "dotenv": "^1.2.0",
+        "ember-cli-deploy-progress": "^1.3.0",
+        "lodash": "^4.0.0",
+        "rsvp": "^3.3.3",
+        "silent-error": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "core-object": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/core-object/-/core-object-2.1.1.tgz",
+          "integrity": "sha1-S3pfHt78sebQ3LWOqxufkL/GZqg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "ember-cli-deploy-build": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-deploy-build/-/ember-cli-deploy-build-1.1.1.tgz",
+      "integrity": "sha512-q6Svm9PhEO2t5bCjsHfwkm36Cdou1eTdzvw00dU/nAHnysmai7sIqEzT7k20zawjGws7CgttZzMz6Oek5TOZ1w==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "ember-cli-deploy-plugin": "^0.2.1",
+        "glob": "^7.1.1",
+        "rsvp": "^3.5.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "ember-cli-deploy-git": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/ember-cli-deploy-git/-/ember-cli-deploy-git-1.3.3.tgz",
+      "integrity": "sha512-skwu+ROq38SuWqcrTh0e/iTCLWOdeANMz2PcnSIiPUcOocVCZUX0FbV4YmQ9Wn6yavzg7VTKrZPxN1YA9eHwYg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^6.11.0",
+        "ember-cli-deploy-plugin": "^0.2.9",
+        "fs-extra": "^5.0.0",
+        "rsvp": "^4.8.1"
+      },
+      "dependencies": {
+        "amd-name-resolver": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.1"
+          }
+        },
+        "broccoli-babel-transpiler": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
+          "integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+          "dev": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "broccoli-funnel": "^2.0.1",
+            "broccoli-merge-trees": "^2.0.0",
+            "broccoli-persistent-filter": "^1.4.3",
+            "clone": "^2.0.0",
+            "hash-for-dep": "^1.2.3",
+            "heimdalljs-logger": "^0.1.7",
+            "json-stable-stringify": "^1.0.0",
+            "rsvp": "^4.8.2",
+            "workerpool": "^2.3.0"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+          "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^1.0.1"
+          }
+        },
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          }
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "merge-trees": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
+          "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+          "dev": true,
+          "requires": {
+            "can-symlink": "^1.0.0",
+            "fs-tree-diff": "^0.5.4",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+          "dev": true
+        }
+      }
+    },
+    "ember-cli-deploy-git-ci": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-deploy-git-ci/-/ember-cli-deploy-git-ci-1.0.1.tgz",
+      "integrity": "sha512-F5lbie3T6vBCHYSCi7yT6KC+4dlM/BkeOv+6oPra0a2Px4q2J3Rv4Yuh8aailOVVRE+2iRyVFM57ijB8QBb9WA==",
+      "dev": true,
+      "requires": {
+        "ember-cli-deploy-plugin": "^0.2.9",
+        "execa": "^0.7.0",
+        "fs-extra": "^4.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
+      }
+    },
+    "ember-cli-deploy-plugin": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/ember-cli-deploy-plugin/-/ember-cli-deploy-plugin-0.2.9.tgz",
+      "integrity": "sha1-o9OVuK2tfvaNi6zdCw9KYbz55lE=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "core-object": "2.0.6",
+        "lodash.clonedeep": "^4.5.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "core-object": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/core-object/-/core-object-2.0.6.tgz",
+          "integrity": "sha1-YBNLnED/abJ7wV6C25ReTfeClhs=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "ember-cli-deploy-progress": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-deploy-progress/-/ember-cli-deploy-progress-1.3.0.tgz",
+      "integrity": "sha1-GGY97tJbTVOXR2My8l7tPD/fIlo=",
+      "dev": true
     },
     "ember-cli-get-component-path-option": {
       "version": "1.0.0",
@@ -9659,7 +9968,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10074,7 +10384,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10130,6 +10441,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10173,12 +10485,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "console-ui": "^3.0.0",
     "cz-conventional-changelog": "^2.1.0",
     "ember-cli": "~3.7.1",
+    "ember-cli-deploy": "^1.0.2",
+    "ember-cli-deploy-build": "^1.1.1",
+    "ember-cli-deploy-git": "^1.3.3",
+    "ember-cli-deploy-git-ci": "^1.0.1",
     "ember-cli-code-coverage": "^1.0.0-beta.8",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^2.1.0",
@@ -92,7 +96,7 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "demoURL": "https://dunnkers.github.io/ember-polymer/"
+    "demoURL": "https://bbvaengineering.github.io/ember-cli-polymer-bundler"
   },
   "config": {
     "commitizen": {

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -32,16 +32,6 @@
 	</paper-tabs>
 </section>
 <section>
-	<paper-dropdown-menu label="Dinosaurs">
-		<paper-listbox slot="dropdown-content">
-			<paper-item>allosaurus</paper-item>
-			<paper-item>brontosaurus</paper-item>
-			<paper-item>carcharodontosaurus</paper-item>
-			<paper-item>diplodocus</paper-item>
-		</paper-listbox>
-	</paper-dropdown-menu>
-</section>
-<section>
 	<paper-fab mini icon="favorite"></paper-fab>
 </section>
 <section>


### PR DESCRIPTION
- The import link tag has been moved to the footer to ensure that polyfills are loaded before it (they are included in vendor).
- This change also allows to publish the demo in gh-pages. The configuration for the deploy is taken from https://github.com/BBVAEngineering/ember-cli-web-components
